### PR TITLE
Enhancement: Display Engine Version Information (0.9.x branch)

### DIFF
--- a/modules/GUI.py
+++ b/modules/GUI.py
@@ -28,6 +28,32 @@ class GUIRoot:
 		self.needRedraw = {}
 		self.modalElement = None
 		self.keyTarget = None
+
+		hasVersion = hasattr(VS, 'EngineVersion')
+		# get the engine version tuple in a displayable format
+		# if it needs to be compared, then use the original tuple version
+		ev = (
+			VS.EngineVersion().GetVersion()
+			if hasVersion
+			else (0, 7, 0, 'unknown') # VS 0.7.x was the last version without this API
+		)
+		engineVersion = '.'.join(
+			[
+				str(i)
+				for i in ev
+			]
+		)
+
+		apiVersion = (
+			VS.EngineVersion().GetAssetAPIVersion()
+			if hasVersion
+			else 0
+		)
+
+		trace(TRACE_WARNING, "::: What's in VS object %s :::" %(dir(VS)))
+		trace(TRACE_WARNING, "::: Engine Version {0} :::".format(engineVersion))
+		trace(TRACE_WARNING, "::: Asset API Version {0} :::".format(apiVersion))
+
 		Base.GlobalKeyPython('#\nfrom GUI import GUIRoot\nGUIRootSingleton.keyEvent()\n')
 
 	def setScreenDimensions(self,screenX,screenY):


### PR DESCRIPTION
Output the Engine Version and the Engine API Version for diagnostics. A future PR can take are of checking for a minimum version, which should be done against the Engine API Version.

Port of https://github.com/vegastrike/Assets-Production/pull/80